### PR TITLE
add Firefox Developer Edition support

### DIFF
--- a/noctrlq.sh
+++ b/noctrlq.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 W=`xdotool getactivewindow`                                                     
-S1=`xprop -id ${W} |awk '/WM_CLASS/{print $4}'`                                 
-if [ $S1 != '"Firefox"' ]; then
+S1=`xprop -id ${W} |awk -F '"' '/WM_CLASS/{print $4}'`                                 
+if [ "$S1" != "Firefox" ] && [ "$S1" != "Firefox Developer Edition" ]; then
 	xvkbd -xsendevent -text "\Cq"
 #	echo $S1
 fi


### PR DESCRIPTION
Firefox Developer Edition has different WM_CLASS, so the script was not working for it. I added a separate check for it.
Tested with Firefox Developer Edition 58 