### PR TITLE
Fixed i3config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A workaround for Firefox 57 Quantum breaking CtrlQ Disable Extensions on Linux
 Bind the script to Ctrl+Q system wide. For example, I use i3wm, so I have this in my i3 config
 
 ```
-bindsym Ctrl+q exec ~/noctrlq.sh
+bindsym Control+q exec ~/noctrlq.sh
 ```
 
 You might need to install `xdotool` and `xvkbd`.


### PR DESCRIPTION
According to i3 user guide, `Control` should be used in i3 config, not `Ctrl`. (See https://i3wm.org/docs/userguide.html#keybindings).

By the way, thank you for sharing your script, it's awesome :+1: 