### PR TITLE
add xvkbd solution again

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,18 @@ Bind the script to Ctrl+Q system wide. For example, I use i3wm, so I have this i
 bindsym Control+q exec ~/noctrlq.sh
 ```
 
-You might need to install `xdotool` and `xvkbd`.
+You might need to install `xdotool`.
 
 # How it works
 I gets the active window using xdotool and if it's not Firefox, it uses xvkbd to forward the Ctrl+Q onto it, otherwise it is Firefox and it doesn't. Much thank to this StackOverflow question: https://askubuntu.com/questions/97213/application-specific-key-combination-remapping
 
 # Why the fuck?
 The geniuses over at Mozilla broke every single method of turning off Ctrl+Q to quit in Firefox on Linux when they released 57/Quantum. There is a Ctrl+Q bypass addon written in WebExtensions, but a bug exists in the Linux version of Firefox that makes that addon not work (only works on macOS (╯°□°）╯︵ ┻━┻) and has been unfixed for [literally fucking years](https://bugzilla.mozilla.org/show_bug.cgi?id=1325692).
+
+# It doesn't work!
+
+xdotool is considered to be [very buggy](https://wiki.archlinux.org/index.php/Xorg#Automation)
+
+Try using the `noctrlq_xvkbd.sh` script instead.
+
+Make sure `xvkbd` installed for this.

--- a/noctrlq_xvkbd.sh
+++ b/noctrlq_xvkbd.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+W="$(xdotool getactivewindow)"
+S1="$(xprop -id "$W" | awk -F '"' '/WM_CLASS/{print tolower($4)}')"
+if [ "$S1" != "firefox" ] && [ "$S1" != "firefox developer edition" ]; then
+	xvkbd -xsendevent -text "\Cq"
+fi


### PR DESCRIPTION
xdotool does not always work properly (though getactivewindow still seems to work fine).
xdotool is appearently [known to be buggy](https://wiki.archlinux.org/index.php/Xorg#Automation)

xvkbd may still be a more stable solution.
I left the xdotool as the default because for users that don't have problems with it that's probably easier to use.

fixes #20 